### PR TITLE
fix(signin): exibe mensagem segura da API em falhas de login

### DIFF
--- a/src/i18n/locales/en-us.ts
+++ b/src/i18n/locales/en-us.ts
@@ -6,6 +6,15 @@ export default {
       user: 'User',
       password: 'Password',
       enter: 'Enter',
+      errors: {
+        invalidCredentials: 'Invalid username or password.',
+        invalidRequest: 'Please enter your username and password.',
+        serviceUnavailable:
+          'The authentication service is unavailable. Please try again in a few moments.',
+        network:
+          'Could not reach the server. Check your connection and try again.',
+        unexpected: 'We could not complete your sign in. Please try again.',
+      },
     },
 
     dashboard: {

--- a/src/i18n/locales/es-ES.ts
+++ b/src/i18n/locales/es-ES.ts
@@ -7,6 +7,15 @@ export default {
       user: 'Usuario',
       password: 'contraseña',
       enter: 'Entrar',
+      errors: {
+        invalidCredentials: 'Usuario o contraseña inválidos.',
+        invalidRequest: 'Ingrese usuario y contraseña.',
+        serviceUnavailable:
+          'No fue posible acceder al servicio de autenticación. Inténtelo de nuevo en unos instantes.',
+        network:
+          'No fue posible conectar con el servidor. Verifique su conexión e inténtelo de nuevo.',
+        unexpected: 'No fue posible completar el inicio de sesión. Inténtelo de nuevo.',
+      },
     },
 
     dashboard: {

--- a/src/i18n/locales/pt-br.ts
+++ b/src/i18n/locales/pt-br.ts
@@ -7,6 +7,15 @@ export default {
       user: 'Usuário',
       password: 'Senha',
       enter: 'Entrar',
+      errors: {
+        invalidCredentials: 'Usuário ou senha inválidos.',
+        invalidRequest: 'Informe usuário e senha.',
+        serviceUnavailable:
+          'Não foi possível acessar o serviço de autenticação. Tente novamente em alguns instantes.',
+        network:
+          'Não foi possível conectar ao servidor. Verifique sua conexão e tente novamente.',
+        unexpected: 'Não foi possível concluir o login. Tente novamente.',
+      },
     },
 
     dashboard: {

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -47,14 +47,16 @@ const SignIn: React.FC = () => {
         form.password,
       );
       if (!data?.success || !data?.data?.token) {
-        throw new Error('user not found');
+        toggleLoader(false);
+        toast.error(t(ProjectService.resolveLoginErrorKey(data)));
+        return;
       }
       const user = ProjectService.mapLoginToUser(data.data);
       updateUser(user);
       history.push('/');
     } catch (error) {
       toggleLoader(false);
-      toast.error('Usuário não encontrado');
+      toast.error(t(ProjectService.resolveLoginErrorKey(error)));
     }
   };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -41,7 +41,10 @@ newAPI.interceptors.request.use(config => {
 newAPI.interceptors.response.use(
   response => response,
   error => {
-    if (error?.response?.status === 401) {
+    // 401 vindo do próprio login é credencial inválida, não sessão expirada:
+    // a tela de login trata a mensagem sem redirecionar.
+    const isAuthRequest = String(error?.config?.url || '').includes('/auth/');
+    if (!isAuthRequest && error?.response?.status === 401) {
       localStorage.removeItem(STORAGE_KEY);
       if (
         typeof window !== 'undefined' &&

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -8,6 +8,8 @@ export type LoginType = 'auto' | 'project' | 'franqueado';
 interface LoginApiResponse {
   success: boolean;
   message?: string;
+  /** Código estável de erro devolvido pela API (ver AuthErrorCodes no back). */
+  code?: string;
   data: {
     token: string;
     role: AuthRole;
@@ -42,6 +44,42 @@ export const login = (login: string, password: string, type: LoginType = 'auto')
     login,
     password,
   });
+};
+
+const LOGIN_ERROR_KEYS: Record<string, string> = {
+  invalid_credentials: 'signIn.errors.invalidCredentials',
+  invalid_request: 'signIn.errors.invalidRequest',
+  auth_service_unavailable: 'signIn.errors.serviceUnavailable',
+  unexpected_error: 'signIn.errors.unexpected',
+};
+
+/**
+ * Traduz a falha de login em uma chave de i18n. Prioriza o código da API; se ele não
+ * vier (versão antiga do back, proxy, indisponibilidade), cai para o status HTTP.
+ * Aceita tanto um erro do axios quanto o corpo de uma resposta 200 com success=false.
+ */
+export const resolveLoginErrorKey = (error: unknown): string => {
+  const asAxios = error as {
+    response?: { status?: number; data?: LoginApiResponse };
+  };
+  const payload = asAxios?.response?.data ?? (error as LoginApiResponse | undefined);
+
+  const byCode = payload?.code ? LOGIN_ERROR_KEYS[payload.code] : undefined;
+  if (byCode) return byCode;
+
+  const status = asAxios?.response?.status;
+  if (!status) {
+    // Resposta 200 com success=false: a API respondeu, então não é falha de rede.
+    return payload?.success === false
+      ? 'signIn.errors.invalidCredentials'
+      : 'signIn.errors.network';
+  }
+  if (status === 400) return 'signIn.errors.invalidRequest';
+  if (status === 401 || status === 403) return 'signIn.errors.invalidCredentials';
+  if (status === 502 || status === 503 || status === 504) {
+    return 'signIn.errors.serviceUnavailable';
+  }
+  return 'signIn.errors.unexpected';
 };
 
 /** @deprecated use login — mantido se algum código legado ainda importar */


### PR DESCRIPTION
Para de mapear todo erro para "Usuario nao encontrado". Usa o codigo estavel da API (invalid_credentials / auth_service_unavailable / etc.) com fallback por status HTTP e traducoes pt-BR/en/es. Evita limpar a sessao em 401 do proprio endpoint de auth.